### PR TITLE
[DO NOT MERGE] Example dot.op cross compilation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -76,7 +76,9 @@
       "args": [
         "${workspaceFolder}/python/test/unit/language/test_core_amd.py",
         "-k",
-        "test_empty_kernel[int8]"
+        // To list test cases: python -m pytest --collect-only -q test/unit/language/test_core_amd.py | grep doc
+        // "test_empty_kernel[int8]",
+        "test_dot[64-64-64-2-False-False-none-True-float32]"
       ],
       "justMyCode": false,
       "env": {
@@ -87,7 +89,7 @@
       },
       "cwd": "${workspaceFolder}",
       // Comment out if don't want automatic builds
-      "preLaunchTask": "Build"
+      // "preLaunchTask": "Build"
     },
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,55 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "(gdb) test_core_amd",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${command:python.interpreterPath}",
+      "args": [
+        "-m",
+        "pytest",
+        "${workspaceFolder}/python/test/unit/language/test_core_amd.py",
+        "-k",
+        "test_empty_kernel[int8]"
+      ],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [
+        {
+          "name": "PYTHONPATH",
+          "value": "${workspaceFolder}/python"
+        },
+        {
+          "name": "TRITON_DEBUG",
+          "value": "1"
+        },
+        {
+          "name": "LD_LIBRARY_PATH",
+          "value": "/opt/rocm/lib"
+        },
+        {
+          "name": "AMDGCN_ENABLE_DUMP",
+          "value": "1"
+        },
+      ],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        },
+        {
+          "description": "Set Disassembly Flavor to Intel",
+          "text": "-gdb-set disassembly-flavor intel",
+          "ignoreFailures": true
+        }
+      ],
+      // Comment out if don't want automatic builds
+      "preLaunchTask": "Build"
+    },
+    {
       "name": "Python: Current File",
       "type": "python",
       "request": "launch",
@@ -38,7 +87,7 @@
       },
       "cwd": "${workspaceFolder}",
       // Comment out if don't want automatic builds
-      // "preLaunchTask": "Build"
-    }
+      "preLaunchTask": "Build"
+    },
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,7 +34,7 @@
         "LD_LIBRARY_PATH": "/opt/rocm/lib"
       },
       // Comment out if don't want automatic builds
-      // "preLaunchTask": "Build"
+      "preLaunchTask": "Build"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
         "pytest",
         "${workspaceFolder}/python/test/unit/language/test_core_amd.py",
         "-k",
-        "test_empty_kernel[int8]"
+        // "test_empty_kernel[int8]"
+        "test_dot[64-64-64-2-False-False-none-True-float32]"
       ],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,15 +19,13 @@
       "preLaunchTask": "Build"
     },
     {
-      "name": "Python: test_cppprinter",
+      "name": "Python: test_core_amd",
       "type": "python",
       "request": "launch",
       "module": "pytest",
       "console": "integratedTerminal",
       "args": [
-        "${workspaceFolder}/python/test/unit/compiler/test_cppprinter.py",
-        "-k",
-        "test_cpp_cc_rocm"
+        "${workspaceFolder}/python/test/unit/language/test_core_amd.py"
       ],
       "justMyCode": false,
       "env": {
@@ -36,7 +34,7 @@
         "LD_LIBRARY_PATH": "/opt/rocm/lib"
       },
       // Comment out if don't want automatic builds
-      "preLaunchTask": "Build"
+      // "preLaunchTask": "Build"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,8 @@
       "env": {
         "PYTHONPATH": "${workspaceFolder}/python",
         "TRITON_DEBUG": "1",
-        "LD_LIBRARY_PATH": "/opt/rocm/lib"
+        "LD_LIBRARY_PATH": "/opt/rocm/lib",
+        "AMDGCN_ENABLE_DUMP": "1",
       },
       "cwd": "${workspaceFolder}",
       // Comment out if don't want automatic builds

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,42 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Current File",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal",
+      "justMyCode": false,
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/python",
+        "TRITON_DEBUG": "1"
+      },
+      // Comment out if don't want automatic builds
+      "preLaunchTask": "Build"
+    },
+    {
+      "name": "Python: test_cppprinter",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "console": "integratedTerminal",
+      "args": [
+        "${workspaceFolder}/python/test/unit/compiler/test_cppprinter.py",
+        "-k",
+        "test_cpp_cc_rocm"
+      ],
+      "justMyCode": false,
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/python",
+        "TRITON_DEBUG": "1",
+        "LD_LIBRARY_PATH": "/opt/rocm/lib"
+      },
+      // Comment out if don't want automatic builds
+      "preLaunchTask": "Build"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,6 +35,7 @@
         "TRITON_DEBUG": "1",
         "LD_LIBRARY_PATH": "/opt/rocm/lib"
       },
+      "cwd": "${workspaceFolder}",
       // Comment out if don't want automatic builds
       // "preLaunchTask": "Build"
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,7 +25,9 @@
       "module": "pytest",
       "console": "integratedTerminal",
       "args": [
-        "${workspaceFolder}/python/test/unit/language/test_core_amd.py"
+        "${workspaceFolder}/python/test/unit/language/test_core_amd.py",
+        "-k",
+        "test_empty_kernel[int8]"
       ],
       "justMyCode": false,
       "env": {
@@ -34,7 +36,7 @@
         "LD_LIBRARY_PATH": "/opt/rocm/lib"
       },
       // Comment out if don't want automatic builds
-      "preLaunchTask": "Build"
+      // "preLaunchTask": "Build"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,38 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "windows": {
+    "options": {
+      "env": {
+        "REL_WITH_DEB_INFO": "1",
+        "LLVM_SYSPATH": "${workspaceFolder}/../triton-llvm-releases/llvm-project/build/install"
+      }
+    }
+  },
+  "linux": {
+    "options": {
+      "env": {
+        "DEBUG": "1"
+      }
+    }
+  },
+  "tasks": [
+    {
+      "label": "Build",
+      "type": "shell",
+      "command": "${command:python.interpreterPath}",
+      "args": [
+        "-m",
+        "pip",
+        "install",
+        "-vvv",
+        "-e",
+        "."
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/python",
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,6 +32,11 @@
       ],
       "options": {
         "cwd": "${workspaceFolder}/python",
+        "env": {
+          "TRITON_USE_ROCM": "TRUE",
+          "DEBUG": "TRUE",
+          "TRITON_USE_ASSERT_ENABLED_LLVM": "TRUE",
+        }
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -86,3 +86,15 @@ Supported Platforms:
 Supported Hardware:
   * NVIDIA GPUs (Compute Capability 7.0+)
   * Under development: AMD GPUs, CPUs
+
+# ROCm
+
+```shell
+# rocm platform, hip toolchain
+curl -LO https://repo.radeon.com/amdgpu-install/5.4.3/ubuntu/jammy/amdgpu-install_5.4.50403-1_all.deb
+sudo apt install ./amdgpu-install_5.4.50403-1_all.deb 
+sudo amdgpu-install --usecase=rocmdev,hiplibsdk
+
+# pytorch
+pip install torch --index-url https://download.pytorch.org/whl/rocm5.4.2
+```

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ curl -LO https://repo.radeon.com/amdgpu-install/5.4.3/ubuntu/jammy/amdgpu-instal
 sudo apt install ./amdgpu-install_5.4.50403-1_all.deb 
 sudo amdgpu-install --usecase=rocmdev,hiplibsdk
 
-# pytorch
+# Optional: install pytorch with ROCm support only if a HIP GPU is available
+# if no HIP GPU is available, use the default pytorch
 pip install torch --index-url https://download.pytorch.org/whl/rocm5.4.2
 ```

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -139,7 +139,7 @@ def check_type_supported(dtype):
 def test_empty_kernel(dtype_x, device='cuda'):
     SIZE = 128
 
-    @triton.jit(cc=HIP_CC_ARCH)
+    @triton.jit(debug=True, cc=HIP_CC_ARCH)
     def kernel(X, SIZE: tl.constexpr):
         pass
     check_type_supported(dtype_x)

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -23,7 +23,7 @@ dtypes_with_bfloat16 = dtypes + ['bfloat16']
 torch_dtypes = ['bool'] + int_dtypes + ['uint8'] + float_dtypes + ['bfloat16']
 
 # to trigger cross compilation for inspecting the ROCm lowering pipeline
-HIP_CC_ARCH = ["", "gfx908", "+sramecc,-xnack"]
+HIP_CC_ARCH = ["amdgcn-amd-amdhsa", "gfx908", "+sramecc,-xnack"] # MI100
 
 def reset_cache(fn):
     """

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -148,12 +148,13 @@ def test_empty_kernel(dtype_x, device='cuda'):
 
 
 # generic test functions
+@reset_cache
 def _test_unary(dtype_x, expr, numpy_expr=None, device='cuda'):
     check_type_supported(dtype_x)  # early return if dtype_x is not supported
     SIZE = 128
     # define the kernel / launch-grid
 
-    @triton.jit
+    @triton.jit(debug=True, cc=HIP_CC_ARCH)
     def kernel(Z, X, SIZE: tl.constexpr):
         off = tl.arange(0, SIZE)
         x = tl.load(X + off)

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -148,13 +148,12 @@ def test_empty_kernel(dtype_x, device='cuda'):
 
 
 # generic test functions
-@reset_cache
 def _test_unary(dtype_x, expr, numpy_expr=None, device='cuda'):
     check_type_supported(dtype_x)  # early return if dtype_x is not supported
     SIZE = 128
     # define the kernel / launch-grid
 
-    @triton.jit(debug=True, cc=HIP_CC_ARCH)
+    @triton.jit()
     def kernel(Z, X, SIZE: tl.constexpr):
         off = tl.arange(0, SIZE)
         x = tl.load(X + off)
@@ -1259,6 +1258,7 @@ def test_permute(dtype_str, shape, perm, device='cuda'):
                           for col_a in [False]
                           for col_b in [False]
                           for dtype in ['int8', 'float16', 'float32']])
+@reset_cache
 def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, dtype, device='cuda'):
     capability = torch.cuda.get_device_capability()
 
@@ -1284,7 +1284,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, dtype, devi
     torch.backends.cuda.matmul.allow_tf32 = allow_tf32
 
     # triton kernel
-    @triton.jit
+    @triton.jit(debug=True, cc=HIP_CC_ARCH)
     def kernel(X, stride_xm, stride_xk,
                Y, stride_yk, stride_yn,
                W, stride_wn, stride_wl,

--- a/python/test/unit/language/test_core_amd.py
+++ b/python/test/unit/language/test_core_amd.py
@@ -22,10 +22,13 @@ dtypes = int_dtypes + uint_dtypes + float_dtypes
 dtypes_with_bfloat16 = dtypes + ['bfloat16']
 torch_dtypes = ['bool'] + int_dtypes + ['uint8'] + float_dtypes + ['bfloat16']
 
+# to trigger cross compilation for inspecting the ROCm lowering pipeline
+HIP_CC_ARCH = ["", "gfx908", "+sramecc,-xnack"]
 
 def reset_cache(fn):
     """
     Decorator to reset the cache directory before running a test.
+    Useful for forcing compilation.
     """
     tmp_dir = os.path.join(os.getcwd(), ".tmp")
 
@@ -136,7 +139,7 @@ def check_type_supported(dtype):
 def test_empty_kernel(dtype_x, device='cuda'):
     SIZE = 128
 
-    @triton.jit
+    @triton.jit(cc=HIP_CC_ARCH)
     def kernel(X, SIZE: tl.constexpr):
         pass
     check_type_supported(dtype_x)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -320,7 +320,7 @@ def {self.fn.__name__}({', '.join(self.arg_names)}, grid, num_warps=4, num_stage
         if callable(arg):
           raise TypeError(f"Callable constexpr at index {{i}} is not supported")
       if not self._call_hook(key, signature, device, constants, num_warps, num_stages, extern_libs, configs):
-        bin = triton.compile(self, signature=signature, device=device, constants=constants, num_warps=num_warps, num_stages=num_stages, extern_libs=extern_libs, configs=configs, debug=self.debug)
+        bin = triton.compile(self, signature=signature, device=device, constants=constants, num_warps=num_warps, num_stages=num_stages, extern_libs=extern_libs, configs=configs, debug=self.debug, cc=self.cc)
         if not warmup:
             bin.c_wrapper(grid_0, grid_1, grid_2, bin.num_warps, bin.shared, stream, bin.cu_function, triton.compiler.CompiledKernel.launch_enter_hook, triton.compiler.CompiledKernel.launch_exit_hook, bin, *args)
         self.cache[device][key] = bin
@@ -335,7 +335,8 @@ def {self.fn.__name__}({', '.join(self.arg_names)}, grid, num_warps=4, num_stage
         exec(src, scope)
         return scope[self.fn.__name__]
 
-    def __init__(self, fn, version=None, do_not_specialize=None, debug=None, noinline=None):
+    def __init__(self, fn, version=None, do_not_specialize=None, debug=None, noinline=None, cc=None):
+        self.cc = cc    # HACK: initiate cross compilation with existing JIT-based test infrastructure, remove when done with investigation
         self.fn = fn
         self.module = fn.__module__
         self.version = version

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -441,6 +441,7 @@ def jit(
     debug: Optional[bool] = None,
     noinline: Optional[bool] = None,
     interpret: Optional[bool] = None,
+    cc: Optional[bool] = None,
 ) -> Union[JITFunction[T], Callable[[T], JITFunction[T]]]:
     """
     Decorator for JIT-compiling a function using the Triton compiler.
@@ -472,6 +473,7 @@ def jit(
                 do_not_specialize=do_not_specialize,
                 debug=debug,
                 noinline=noinline,
+                cc=cc
             )
     if fn is not None:
         return decorator(fn)


### PR DESCRIPTION
This hacks the triton.jit() call to support cross compilation in order to reuse AMD's existing tests with minimal churn.

It lowers the tl.dot op to GCN.

The deployment and launch stages will fail because cubin is not found. This is by design because triton.jit should not be used for cross compilation.